### PR TITLE
Small fix to AlertConditions API

### DIFF
--- a/newrelic_api/alert_conditions.py
+++ b/newrelic_api/alert_conditions.py
@@ -130,7 +130,7 @@ class AlertConditions(Resource):
 
         data = {
             'condition': {
-                'condition_type': condition_type or target_condition['condition_type'],
+                'type': condition_type or target_condition['type'],
                 'name': name or target_condition['name'],
                 'enabled': enabled or target_condition['enabled'],
                 'entities': entities or target_condition['entities'],


### PR DESCRIPTION
This relates to PR #29. Since your fork merged it, I wanted to keep the momentum going, but let me know if I should open this elsewhere :)

Update ``condition_type`` variable to ``type`` to match [API](https://docs.newrelic.com/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api/rest-api-calls-new-relic-alerts#conditions).